### PR TITLE
Handle near-empty devices when checking disk space

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -165,7 +165,7 @@ def do_update():
 
 def check_diskspace(dir):
     df = sh_out("df %s" % dir)
-    nums = re.findall(r'\d+\w+\d+\w+\d+', df)
+    nums = re.findall(r'(?<=\s)\d+(?=\s+)', df)
     if not nums or len(nums) != 3:
         info("Warning: unable to check available diskspace")
     if (int(nums[2]) / 1024) < DISK_USAGE_MB:


### PR DESCRIPTION
Fixes #31.

Updates regex used in `check_diskspace` to work on devices with <10000K used.