### PR TITLE
Add missing errno import

### DIFF
--- a/rpi-source
+++ b/rpi-source
@@ -19,6 +19,7 @@ import subprocess
 import re
 import json
 import platform
+import errno
 
 # used by archive file and unpacked archive
 DISK_USAGE_MB = 900


### PR DESCRIPTION
errno is used in the code, but not imported, leading to an exception.